### PR TITLE
remove sensitivity chart from the output

### DIFF
--- a/src/components/Results/ResultsCharts.tsx
+++ b/src/components/Results/ResultsCharts.tsx
@@ -2,21 +2,13 @@ import React from 'react';
 import { YearlyResult } from '../../models/Types';
 import {
   Area,
-  Bar,
   CartesianGrid,
   ComposedChart,
-  Label,
   Legend,
   Line,
-  LineChart,
-  Scatter,
-  ScatterChart,
   Tooltip,
   XAxis,
-  YAxis,
-  ZAxis
-} from 'recharts';
-import { VictoryLabel } from 'victory';
+  YAxis} from 'recharts';
 import { formatNumber } from '../Shared/util';
 import { OutputModSensitivity } from '@ucdavis/tea/output.model';
 
@@ -97,162 +89,9 @@ export const ResultsCharts = (props: Props) => {
     );
   };
 
-  const renderSensitivityCharts = () => {
-    if (!props.sensitivityResults) {
-      return null;
-    }
-    const capitalCost = [];
-    const fuelCost = [];
-    const debtRatio = [];
-    const debtInterestRate = [];
-    const costOfEquity = [];
-    const netEfficiency = [];
-    const capacityFactor = [];
-    for (
-      let index = 0;
-      index < props.sensitivityResults.CapitalCost.relativeChangeCOE.length;
-      index++
-    ) {
-      capitalCost.push({
-        coe: formatNumber(
-          props.sensitivityResults.CapitalCost.relativeChangeCOE[index]
-        ),
-        relativeChange: formatNumber(
-          props.sensitivityResults.CapitalCost.relativeChange[index]
-        )
-      });
-      fuelCost.push({
-        coe: formatNumber(
-          props.sensitivityResults.BiomassFuelCost.relativeChangeCOE[index]
-        ),
-        relativeChange: formatNumber(
-          props.sensitivityResults.BiomassFuelCost.relativeChange[index]
-        )
-      });
-      debtRatio.push({
-        coe: formatNumber(
-          props.sensitivityResults.DebtRatio.relativeChangeCOE[index]
-        ),
-        relativeChange: formatNumber(
-          props.sensitivityResults.DebtRatio.relativeChange[index]
-        )
-      });
-      debtInterestRate.push({
-        coe: formatNumber(
-          props.sensitivityResults.DebtInterestRate.relativeChangeCOE[index]
-        ),
-        relativeChange: formatNumber(
-          props.sensitivityResults.DebtInterestRate.relativeChange[index]
-        )
-      });
-      costOfEquity.push({
-        coe: formatNumber(
-          props.sensitivityResults.CostOfEquity.relativeChangeCOE[index]
-        ),
-        relativeChange: formatNumber(
-          props.sensitivityResults.CostOfEquity.relativeChange[index]
-        )
-      });
-      netEfficiency.push({
-        coe: formatNumber(
-          props.sensitivityResults.NetStationEfficiency.relativeChangeCOE[index]
-        ),
-        relativeChange: formatNumber(
-          props.sensitivityResults.NetStationEfficiency.relativeChange[index]
-        )
-      });
-      capacityFactor.push({
-        coe: formatNumber(
-          props.sensitivityResults.CapacityFactor.relativeChangeCOE[index]
-        ),
-        relativeChange: formatNumber(
-          props.sensitivityResults.CapacityFactor.relativeChange[index]
-        )
-      });
-    }
-
-    const xRange = [-200,400];
-    const yRange = [-100,250];
-    return (
-      <>
-        <h3>Sensitivity Analysis</h3>
-        <ScatterChart
-          ref={props.sensitivityChartRef}
-          width={700}
-          height={600}
-          margin={{
-            top: 20,
-            bottom: 20,
-            left: 20
-          }}
-        >
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis type="number" dataKey='relativeChange' domain={[xRange[0], xRange[1]]}>
-            <Label value="% Relative Change" position="insideBottom" offset={-20} className="sensitivity-x-label" />
-          </XAxis>
-          <YAxis type="number" dataKey='coe' domain={[yRange[0], yRange[1]]}>
-            <Label value="Relative Change in COE (%)" angle={-90} position="insideLeft" className="sensitivity-y-label" />
-          </YAxis>
-          <Tooltip cursor={{ strokeDasharray: '3 3' }}/>
-          <Legend wrapperStyle={{ paddingTop: "40px" }}/>
-          <Scatter
-            name='Capital Cost'
-            data={capitalCost}
-            fill='#4B0082'
-            dataKey='coe'
-            line
-          />
-          <Scatter
-            name='Fuel Cost'
-            data={fuelCost}
-            fill='#8B008B'
-            dataKey='coe'
-            line
-          />
-          <Scatter
-            name='Debt Ratio'
-            data={debtRatio}
-            fill='#FFD700'
-            dataKey='coe'
-            line
-          />
-          <Scatter
-            name='Debt Interest Rate'
-            data={debtInterestRate}
-            fill='#CD5C5C'
-            dataKey='coe'
-            line
-          />
-          <Scatter
-            name='Cost Of Equity'
-            data={costOfEquity}
-            fill='#800000'
-            dataKey='coe'
-            line
-          />
-          <Scatter
-            name='Net Efficiency'
-            data={netEfficiency}
-            fill='#008B8B'
-            dataKey='coe'
-            line
-          />
-          <Scatter
-            name='Capacity Factor'
-            data={capacityFactor}
-            fill='#00008B'
-            dataKey='coe'
-            line
-          />
-        </ScatterChart>
-      </>
-    );
-  };
-
   return (
     <>
       {renderCostCharts()}
-      {renderSensitivityCharts()}
     </>
   );
 };

--- a/src/components/Results/ResultsExport.tsx
+++ b/src/components/Results/ResultsExport.tsx
@@ -827,30 +827,6 @@ export const ResultsExport = (props: Props) => {
       ]
     });
 
-    // turn the chart into an image and embed it
-    if (props.sensitivityChart) {
-      // we should always have the chart but if it's null for some reason skip it instead of breaking
-      const chartSvg = props.sensitivityChart.current.container.children[0];
-
-      // TODO: legend isn't in SVG so it currently isn't included
-      const pngData = await svgToPng(chartSvg, 800, 600);
-
-      // add image to workbook by base64
-      const chartImageId2 = workbook.addImage({
-        base64: pngData,
-        extension: 'png'
-      });
-
-      const legendImageId = workbook.addImage({
-        base64: myBase64Image,
-        extension: 'png'
-      });
-
-      // insert an image over B2:D6
-      worksheet.addImage(chartImageId2, 'B73:J94');
-      worksheet.addImage(legendImageId, 'B97:J100');
-    }
-
     const workbookBuffer = await workbook.xlsx.writeBuffer();
 
     // send file to client
@@ -867,35 +843,6 @@ export const ResultsExport = (props: Props) => {
       </Button>
     </p>
   );
-};
-
-const svgToPng = (svg: any, width: number, height: number) => {
-  return new Promise<string>((resolve, reject) => {
-    let canvas = document.createElement('canvas');
-    canvas.width = width;
-    canvas.height = height;
-    const ctx = canvas.getContext('2d');
-
-    if (!ctx) throw Error('No canvas context found');
-
-    // Set background to white
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, width, height);
-
-    let xml = new XMLSerializer().serializeToString(svg);
-    let dataUrl = 'data:image/svg+xml;utf8,' + encodeURIComponent(xml);
-    let img = new Image(width, height);
-
-    img.onload = () => {
-      ctx.drawImage(img, 0, 0);
-      let imageData = canvas.toDataURL('image/png', 1.0);
-      resolve(imageData);
-    };
-
-    img.onerror = () => reject();
-
-    img.src = dataUrl;
-  });
 };
 
 export default ResultsExport;


### PR DESCRIPTION
Left the sensitivity info in the types as well as props, in case we want to display it in a different way or bring back the chart later.

fixes #149