### PR TITLE
need to ignore custom renderer for plant layer

### DIFF
--- a/src/components/Map/Layers/PlantLegend.tsx
+++ b/src/components/Map/Layers/PlantLegend.tsx
@@ -6,6 +6,25 @@ export const PlantLegend = () => (
     className='esriLegendService'
     style={{ display: 'block' }}
   >
+    See{' '}
+    <a
+      target='_blank'
+      rel='noopener noreferrer'
+      href='http://www.arcgis.com/home/webmap/viewer.html?url=https://services3.arcgis.com/bWPjFyq029ChCGur/ArcGIS/rest/services/Power_Plant/FeatureServer/0&source=sd'
+    >
+      the ArcGIS map viewer
+    </a>
+    for an interactive map of the plant locations, including custom icons for
+    each plant type.
+  </div>
+);
+
+export const PlantLegendWithRenderer = () => (
+  <div
+    id='legend-main_Power_Plant_8615'
+    className='esriLegendService'
+    style={{ display: 'block' }}
+  >
     <table width='95%'>
       <tbody>
         <tr>

--- a/src/components/Map/MapContainer.tsx
+++ b/src/components/Map/MapContainer.tsx
@@ -662,6 +662,7 @@ export const MapContainer = () => {
             url={
               'https://services3.arcgis.com/bWPjFyq029ChCGur/ArcGIS/rest/services/Power_Plant/FeatureServer/0'
             }
+            ignoreRenderer={true}
           />
         )}
         {externalLayers.includes('county') && (


### PR DESCRIPTION
CEC-hosted Power Plant layer has been updated to use complex marker rendering which isn't supported by our marker library.  So this turns off the custom markers for just this layer and adds a legend with a link to arcGIS web map viewer.

closes #167