### PR TITLE
update default diesel fuel price and escalate it in the future years

### DIFF
--- a/src/components/Inputs/Frcs/FrcsInputsContainer.test.tsx
+++ b/src/components/Inputs/Frcs/FrcsInputsContainer.test.tsx
@@ -6,7 +6,7 @@ import { FrcsInputsContainer } from './FrcsInputsContainer';
 const frcsInputsExample: FrcsInputs = {
   system: 'Ground-Based Mech WT',
   treatmentid: 1,
-  dieselFuelPrice: 3.61,
+  dieselFuelPrice: 2.24,
   wageFaller: 35.13, // CA FallBuckWage May 2020
   wageOther: 22.07, // CA AllOthersWage May 2020
   laborBenefits: 35, // Assume a nationwide average of 35% for benefits and other payroll costs

--- a/src/components/Inputs/Frcs/FrcsInputsContainer.tsx
+++ b/src/components/Inputs/Frcs/FrcsInputsContainer.tsx
@@ -193,6 +193,10 @@ export const FrcsInputsContainer = (props: Props) => {
                 />
                 <InputGroupAddon addonType='append'>$/gal</InputGroupAddon>
               </InputGroup>
+              <FormText color='muted'>
+                The default reflects 2021 wholesale diesel price and retail
+                price may be higher
+              </FormText>
             </FormGroup>
             <FormGroup>
               <Label>Hourly wage for Fallers</Label>

--- a/src/components/Map/MapContainer.tsx
+++ b/src/components/Map/MapContainer.tsx
@@ -109,7 +109,7 @@ export const MapContainer = () => {
   const frcsInputsExample: FrcsInputs = {
     system: 'Ground-Based Mech WT',
     treatmentid: 1,
-    dieselFuelPrice: 3.61,
+    dieselFuelPrice: 2.24,
     wageFaller: 35.13, // CA FallBuckWage May 2020
     wageOther: 22.07, // CA AllOthersWage May 2020
     laborBenefits: 35, // Assume a nationwide average of 35% for benefits and other payroll costs
@@ -350,7 +350,8 @@ export const MapContainer = () => {
         lng: biomassCoordinates.lng,
         system: frcsInputs.system,
         treatmentid: frcsInputs.treatmentid,
-        dieselFuelPrice: frcsInputs.dieselFuelPrice,
+        dieselFuelPrice:
+          frcsInputs.dieselFuelPrice * (1 + generalInflation / 100) ** index,
         biomassTarget: allYearResults.biomassTarget, // green metric tons per year
         firstYear: years[0],
         year: years[index],


### PR DESCRIPTION
Use the latest wholesale price of 2.24 $/gal reported on 12/15/2021 by the Energy Information Administration