### PR TITLE
Grab move-in from new API endpoint

### DIFF
--- a/src/components/Map/ClusterTransportationMoveInLayer.tsx
+++ b/src/components/Map/ClusterTransportationMoveInLayer.tsx
@@ -56,7 +56,7 @@ export const ClusterTransportationMoveInLayer = (props: Props) => {
   ]);
 
   if (geoJson) {
-    return <GeoJSON key={`geoyear-movein-${currentComputedYear}`} data={geoJson} />;
+    return <GeoJSON color="purple" key={`geoyear-movein-${currentComputedYear}`} data={geoJson} />;
   } else {
     return <></>;
   }

--- a/src/components/Map/ClusterTransportationMoveInLayer.tsx
+++ b/src/components/Map/ClusterTransportationMoveInLayer.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import { GeoJSON } from 'react-leaflet';
+import { FeatureCollection } from 'geojson';
+import { MapCoordinates, YearlyResult } from '../../models/Types';
+import { serviceUrl } from '../Shared/config';
+
+interface Props {
+  facilityCoordinates: MapCoordinates;
+  years: number[];
+  yearlyResults: YearlyResult[];
+  selectedYearIndex: number;
+}
+
+export const ClusterTransportationMoveInLayer = (props: Props) => {
+  const [currentComputedYear, setCurrentComputedYear] = useState<number>(
+    props.selectedYearIndex
+  );
+  const [geoJson, setGeoJson] = useState<FeatureCollection>();
+
+  useEffect(() => {
+    const yearResult = props.yearlyResults[props.selectedYearIndex];
+
+    if (!yearResult) {
+      setGeoJson(undefined);
+      setCurrentComputedYear(-1);
+      return;
+    }
+    const clusters = yearResult.clusters;
+
+    const body = {
+      facilityLat: props.facilityCoordinates.lat,
+      facilityLng: props.facilityCoordinates.lng,
+      clusters
+    };
+
+    const fetchRoutes = async () => {
+      const routeResults = await fetch(serviceUrl + 'processMoveIn', {
+        mode: 'cors',
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }).then(res => res.json());
+
+      setGeoJson(routeResults);
+      setCurrentComputedYear(props.selectedYearIndex);
+    };
+
+    fetchRoutes();
+  }, [
+    props.facilityCoordinates.lat,
+    props.facilityCoordinates.lng,
+    props.selectedYearIndex,
+    props.yearlyResults
+  ]);
+
+  if (geoJson) {
+    return <GeoJSON key={`geoyear-movein-${currentComputedYear}`} data={geoJson} />;
+  } else {
+    return <></>;
+  }
+};

--- a/src/components/Map/ClusterTransportationRoutesLayer.tsx
+++ b/src/components/Map/ClusterTransportationRoutesLayer.tsx
@@ -56,7 +56,7 @@ export const ClusterTransportationRoutesLayer = (props: Props) => {
   ]);
 
   if (geoJson) {
-    return <GeoJSON key={`geoyear-${currentComputedYear}`} data={geoJson} />;
+    return <GeoJSON color="orange" key={`geoyear-${currentComputedYear}`} data={geoJson} />;
   } else {
     return <></>;
   }

--- a/src/components/Map/MapContainer.tsx
+++ b/src/components/Map/MapContainer.tsx
@@ -54,9 +54,9 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { PrintControl } from './PrintControl';
 import { checkFrcsValidity, checkTeaValidity } from '../Inputs/validation';
-import { TripLayers } from './TripLayers';
 import { CustomMarker } from './CustomMarker';
 import { ClusterTransportationRoutesLayer } from './ClusterTransportationRoutesLayer';
+import { ClusterTransportationMoveInLayer } from './ClusterTransportationMoveInLayer';
 
 const { BaseLayer } = LayersControl;
 
@@ -752,9 +752,10 @@ export const MapContainer = () => {
         {yearlyResults.length > 0 && (
           <>
             {showMoveInGeoJson && (
-              <TripLayers
+              <ClusterTransportationMoveInLayer
+                facilityCoordinates={facilityCoordinates}
                 years={years}
-                yearlyGeoJson={tripGeometries}
+                yearlyResults={yearlyResults}
                 selectedYearIndex={selectedYearIndex}
               />
             )}


### PR DESCRIPTION
Associated CECDSS-backend PR removes move-in generation by default, which should save a lot of bytes and processing time.