### PR TITLE
Report additional outputs for chp and gp models

### DIFF
--- a/src/components/Results/ResultsTables.tsx
+++ b/src/components/Results/ResultsTables.tsx
@@ -124,6 +124,7 @@ export const ResultsTable = (props: Props) => {
             props.yearlyResults.length
           )}
           system={props.frcsInputs.system}
+          teaModel={props.teaModel}
         />
       </div>
     </>

--- a/src/components/Results/Technoeconomic/TechnoeconomicTables.tsx
+++ b/src/components/Results/Technoeconomic/TechnoeconomicTables.tsx
@@ -267,6 +267,25 @@ export const TechnoeconomicTables = (props: Props) => {
             </td>
           ))}
         </tr>
+        {props.teaModel === TechnoeconomicModels.gasificationPower && (
+          <tr>
+            <td>Dual Fuel Cost</td>
+            <td>$</td>
+            <td>
+              {formatCurrency(
+                props.cashFlows.reduce(
+                  (sum: number, x: CashFlow) => sum + x.DualFuelCost,
+                  0
+                )
+              )}
+            </td>
+            {props.cashFlows.map((result, i) => (
+              <td key={`dualFuelCost-${i}`}>
+                {formatCurrency(result.DualFuelCost)}
+              </td>
+            ))}
+          </tr>
+        )}
         <tr>
           <td>Non-fuel Expenses</td>
           <td>$</td>

--- a/src/components/Results/Technoeconomic/TechnoeconomicTables.tsx
+++ b/src/components/Results/Technoeconomic/TechnoeconomicTables.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { formatCurrency, formatNumber } from '../../Shared/util';
-import { YearlyResult } from '../../../models/Types';
+import { TechnoeconomicModels, YearlyResult } from '../../../models/Types';
 import { Table } from 'reactstrap';
 import { CashFlow } from '@ucdavis/tea/output.model';
 
@@ -8,6 +8,7 @@ interface Props {
   yearlyResults: YearlyResult[];
   cashFlows: CashFlow[];
   system: String;
+  teaModel: string;
 }
 
 export const TechnoeconomicTables = (props: Props) => {
@@ -334,6 +335,26 @@ export const TechnoeconomicTables = (props: Props) => {
             </td>
           ))}
         </tr>
+        {(props.teaModel === TechnoeconomicModels.genericPowerOnly ||
+          TechnoeconomicModels.gasificationPower) && (
+          <tr>
+            <td>Income--Heat</td>
+            <td>$</td>
+            <td>
+              {formatCurrency(
+                props.cashFlows.reduce(
+                  (sum: number, x: CashFlow) => sum + x.IncomeHeat,
+                  0
+                )
+              )}
+            </td>
+            {props.cashFlows.map((result, i) => (
+              <td key={`incomeHeat-${i}`}>
+                {formatCurrency(result.IncomeHeat)}
+              </td>
+            ))}
+          </tr>
+        )}
         <tr>
           <td>Interest On Debt Reserve</td>
           <td>$</td>

--- a/src/components/Results/Technoeconomic/TechnoeconomicTables.tsx
+++ b/src/components/Results/Technoeconomic/TechnoeconomicTables.tsx
@@ -319,7 +319,7 @@ export const TechnoeconomicTables = (props: Props) => {
           ))}
         </tr>
         <tr>
-          <td>Income Capacity</td>
+          <td>Income--Capacity</td>
           <td>$</td>
           <td>
             {formatCurrency(
@@ -369,23 +369,6 @@ export const TechnoeconomicTables = (props: Props) => {
           {props.cashFlows.map((result, i) => (
             <td key={`interestOnDebtReserve-${i}`}>
               {formatCurrency(result.InterestOnDebtReserve)}
-            </td>
-          ))}
-        </tr>
-        <tr>
-          <td>Income -- Capacity</td>
-          <td>$</td>
-          <td>
-            {formatCurrency(
-              props.cashFlows.reduce(
-                (sum: number, x: CashFlow) => sum + x.IncomeCapacity,
-                0
-              )
-            )}
-          </td>
-          {props.cashFlows.map((result, i) => (
-            <td key={`incomeCapacity-${i}`}>
-              {formatCurrency(result.IncomeCapacity)}
             </td>
           ))}
         </tr>

--- a/src/components/Results/Technoeconomic/TechnoeconomicTables.tsx
+++ b/src/components/Results/Technoeconomic/TechnoeconomicTables.tsx
@@ -355,6 +355,25 @@ export const TechnoeconomicTables = (props: Props) => {
             ))}
           </tr>
         )}
+        {props.teaModel === TechnoeconomicModels.gasificationPower && (
+          <tr>
+            <td>Income--Char/Ash</td>
+            <td>$</td>
+            <td>
+              {formatCurrency(
+                props.cashFlows.reduce(
+                  (sum: number, x: CashFlow) => sum + x.IncomeChar,
+                  0
+                )
+              )}
+            </td>
+            {props.cashFlows.map((result, i) => (
+              <td key={`incomeChar-${i}`}>
+                {formatCurrency(result.IncomeChar)}
+              </td>
+            ))}
+          </tr>
+        )}
         <tr>
           <td>Interest On Debt Reserve</td>
           <td>$</td>

--- a/src/components/Results/Technoeconomic/TechnoeconomicTables.tsx
+++ b/src/components/Results/Technoeconomic/TechnoeconomicTables.tsx
@@ -335,8 +335,8 @@ export const TechnoeconomicTables = (props: Props) => {
             </td>
           ))}
         </tr>
-        {(props.teaModel === TechnoeconomicModels.genericPowerOnly ||
-          TechnoeconomicModels.gasificationPower) && (
+        {(props.teaModel === TechnoeconomicModels.genericCombinedHeatAndPower ||
+          props.teaModel === TechnoeconomicModels.gasificationPower) && (
           <tr>
             <td>Income--Heat</td>
             <td>$</td>
@@ -368,23 +368,6 @@ export const TechnoeconomicTables = (props: Props) => {
           </td>
           {props.cashFlows.map((result, i) => (
             <td key={`interestOnDebtReserve-${i}`}>
-              {formatCurrency(result.InterestOnDebtReserve)}
-            </td>
-          ))}
-        </tr>
-        <tr>
-          <td>Interest On Debt Reserve</td>
-          <td>$</td>
-          <td>
-            {formatCurrency(
-              props.cashFlows.reduce(
-                (sum: number, x: CashFlow) => sum + x.InterestOnDebtReserve,
-                0
-              )
-            )}
-          </td>
-          {props.cashFlows.map((result, i) => (
-            <td key={`interestonDebtReserve-${i}`}>
               {formatCurrency(result.InterestOnDebtReserve)}
             </td>
           ))}


### PR DESCRIPTION
closes #214

- report heat income when the model is chp or gp
- report dual fuel cost when the model is gp
- remove duplicated capacity income and debt reserve interest